### PR TITLE
fix: don't use temp files and handle error

### DIFF
--- a/ext/build.gradle.kts
+++ b/ext/build.gradle.kts
@@ -90,11 +90,23 @@ tasks {
 }
 
 fun execute(vararg command: String): String {
-    val processBuilder = ProcessBuilder(*command)
-    val hashCode = command.joinToString().hashCode().toString()
-    val output = File.createTempFile(hashCode, "")
-    processBuilder.redirectOutput(output)
-    val process = processBuilder.start()
-    process.waitFor()
-    return output.readText().dropLast(1)
+    val process = ProcessBuilder(*command)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+
+    val output = process.inputStream.bufferedReader().readText()
+    val errorOutput = process.errorStream.bufferedReader().readText()
+
+    val exitCode = process.waitFor()
+
+    if (exitCode != 0) {
+        throw IOException(
+            "Command failed with exit code $exitCode. Command: ${command.joinToString(" ")}\n" +
+                    "Stdout:\n$output\n" +
+                    "Stderr:\n$errorOutput"
+        )
+    }
+
+    return output.trim()
 }


### PR DESCRIPTION
- Refactored the `execute` function to use pipes instead of temp files for output capture.
- Added proper error handling by checking exit codes and capturing stderr.